### PR TITLE
Adding proposed changes to the config system

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,17 +75,38 @@ var cloudedCalculator = λ(
 
 ### Setting your AWS credentials
 
-```js
-var lambdaws = require('lambdaws');
+You can set your AWS credentials in one of three ways.
 
-lambdaws.config({
-	accessKey: '', // string, AWS AccessKeyId
-	secretKey: '', // string, AWS AccessKeySecret
-	role: '' // string, AWS ARN. Must have full access to SQS
-});
+1. By default, the AWS SDK looks for credentials in `~/.aws/credentials`. If you do not set anything, lambdaws will use the default profile. For more information see [the docs](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Credentials_from_the_Shared_Credentials_File_____aws_credentials_).
 
-lambdaws.start();
-```
+2. You can use a [different profile](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Using_Profiles_with_the_SDK):
+
+   ```js
+   var lambdaws = require('lambdaws');
+
+   lambdaws.config({
+       credentials: 'my-profile',  // string, profile name.
+       role: ''  // string, AWS ARN. Must have full access to SQS.
+   });
+
+   lambdaws.start();
+   ```
+
+3. You can set the access and secret keys manually:
+
+   ```js
+   var lambdaws = require('lambdaws');
+
+   lambdaws.config({
+       credentials: {
+           accessKey: '',  // string, AWS AccessKeyId.
+           secretKey: '',  // string, AWS AccessKeySecret.
+       },
+       role: ''  // string, AWS ARN. Must have full access to SQS.
+   });
+
+   lambdaws.start();
+   ```
 
 Your AWS user credentials must have access to Lambda, SQS and S3.
 

--- a/example/example.js
+++ b/example/example.js
@@ -3,8 +3,10 @@ var lambdaws = require('../'),
 	λ = lambdaws.create;
 
 lambdaws.config({
-	accessKey: 'YOUR_ACCESS_KEY',
-	secretKey: 'YOUR_SECRET',
+	credentials: {
+		accessKey: 'YOUR_ACCESS_KEY',
+		secretKey: 'YOUR_SECRET',
+	},
 	role: 'LAMBDAWS_ARN_WITH_FULL_ACCESS_TO_SQS', // not necessary if the user has full access
 	region: 'us-east-1'
 });

--- a/lib/lambdaws.js
+++ b/lib/lambdaws.js
@@ -6,8 +6,7 @@ var extend = require('extend'),
     path = require('path');
 
 global.settings = {
-    accessKey: '',
-    secretKey: '',
+    credentials: null,
     region: 'us-west-2',
     sqsQueueName: 'LambdaResultsQueue',
     uploadTimeout: 5000
@@ -55,9 +54,20 @@ exports.config = function (params) {
     aws.config.apiVersions = versions;
     extend(settings, params);
 
+    if (settings.credentials !== null) {
+        if (typeof settings.credentials === 'string') {
+            // Specifying profile
+            aws.config.credentials = new aws.SharedIniFileCredentials({profile: settings.credentials});
+        } else {
+            // Setting keys manually
+            aws.config.update({
+                accessKeyId: settings.credentials.accessKey,
+                secretAccessKey: settings.credentials.secretKey
+            });
+        }
+    }
+
     aws.config.update({
-        accessKeyId: settings.accessKey,
-        secretAccessKey: settings.secretKey,
         region: settings.region
     });
 


### PR DESCRIPTION
These changes allow the user to load AWS keys from ~/.aws/credentials, which
is the preferred way as it prevents having to put keys in code. The user can
do nothing, in which case the default profile is loaded, or they can specify
the `credentials` as a string, which will set the profile to use.

The old system of manually specifying keys has been kept, as it may be useful.