### PR TITLE
Support for external libraries

### DIFF
--- a/lib/LambdaHelper.js
+++ b/lib/LambdaHelper.js
@@ -35,6 +35,7 @@ var _loadModule = function(moduleName) {
 
 var _lambdaize = function (userFunc, externals) {
     
+    // This function is a template that is serialized and some parts are replaced
     function __lambda__ (event, context) {
         var utils               = require('./_utils'),
             callbackHandler     = require('./_callbackHandler'),
@@ -43,8 +44,8 @@ var _lambdaize = function (userFunc, externals) {
         var doneCallback = callbackHandler.getCallback(event, context);
 
         event.args.push(doneCallback);
-        var externals = /*externals*/null;
-        var func = /*user function*/null;
+        var externals = /*externals*/null; // The external libraries to install, injected below
+        var func = /*user function*/null; // The user function or module to run, injected below
 
         var runUserFunction = function() {
             try {
@@ -117,8 +118,11 @@ var _createProxy = function (executionStore, queueInitializedPromise, uploadProm
 };
 
 var _getExternalDependencies = function(deps) {
+    // External dependencies are currently defined within the normal dependencies. 
+    // This is going to change in the next major version, but we had to do so to keep the current API signature
     if(!deps) return [];
     return deps.filter(function(dep) {
+        // External dependencies have a prepending ":"
         return dep[0] === ':';
     });
 };

--- a/lib/LambdaHelper.js
+++ b/lib/LambdaHelper.js
@@ -33,58 +33,43 @@ var _loadModule = function(moduleName) {
     return require(moduleName); // TODO throw better errors if require fails
 };
 
-var _lambdaize = function (userFunc) {
-    // TODO : move this out in a module as a lambda prototype, blueprint, template, whatever
+var _lambdaize = function (userFunc, externals) {
+    
     function __lambda__ (event, context) {
-        var LambdaError = function() {};
-        // TODO (Next iteration) Move requires elsewhere
-        var AWS_sdk = require('aws-sdk'),
-        sqs_svc = new AWS_sdk.SQS();
-        
-        function _sendToSqs(data, afterSentCallback) {
-            var params = {
-                MessageBody: JSON.stringify(data),
-                QueueUrl: event.sqsQueueUrl
-            };
-            sqs_svc.sendMessage(params, function(err) {
-                if(err) console.log('Error sending response to sqs'); 
-                afterSentCallback();
-            });
-        }
+        var utils               = require('./_utils'),
+            callbackHandler     = require('./_callbackHandler'),
+            externalsHandler    = require('./_externalsHandler');
 
-        function _newCallback(arg) {
-            var finishExecution = function() { context.done(null, "Lambdaws done"); };
-            var success = !(arg instanceof LambdaError);
-            _sendToSqs({success: success, data: arg, requestId: context.invokeid}, finishExecution);
-        }
+        var doneCallback = callbackHandler.getCallback(event, context);
 
-        event.args.push(_newCallback);
-
+        event.args.push(doneCallback);
+        var externals = /*externals*/null;
         var func = /*user function*/null;
 
-        try {
+        var runUserFunction = function() {
+            try {
             func.apply(this, event.args);
-        }
-        catch(error) {
-            var objectifyError = function(err) {
-                return Object.getOwnPropertyNames(err).reduce(function(a, c) {
-                    a[c] = err[c];
-                    return a;
-                }, new LambdaError());
-            };
-            _newCallback(objectifyError(error));
-        }
+            }
+            catch(error) {
+                doneCallback(utils.objectifyError(error));
+            }
+        };
+        
+        try { externalsHandler.installExternals(externals, runUserFunction) }
+        catch(error) { doneCallback(utils.objectifyError(error)) }
     }
 
-    return __lambda__.toString().replace('/*user function*/null', userFunc.toString());
+    return __lambda__.toString()
+        .replace('/*user function*/null', userFunc.toString())
+        .replace('/*externals*/null', JSON.stringify(externals));
 }
 
-var _lambdaizeModule = function(handlerName) {
+var _lambdaizeModule = function(handlerName, externals) {
     var functionToCall = typeof(handlerName) === 'string' ? '.' + handlerName : '';
 
     // Requiring the function in module
     var outputModuleCode = "var m = require('./module.js')" + functionToCall + ";";
-    var instrumentedFunction = _lambdaize('m'),
+    var instrumentedFunction = _lambdaize('m', externals),
         instrumentedFunctionWithoutName = instrumentedFunction.replace('function __lambda__', 'function');
 
     // Exporting the instrumented module call
@@ -131,6 +116,13 @@ var _createProxy = function (executionStore, queueInitializedPromise, uploadProm
     return proxy;
 };
 
+var _getExternalDependencies = function(deps) {
+    if(!deps) return [];
+    return deps.filter(function(dep) {
+        return dep[0] === ':';
+    });
+};
+
 // TODO : replace getmodulehash and get function hash for a single function
 // TODO : md5 module and include it in the hash function
 module.exports = function (aws) {
@@ -148,7 +140,8 @@ module.exports = function (aws) {
         var functionIdentifier = _getFunctionHash(func);
 
         if (!proxyStore.hasOwnProperty(functionIdentifier)) {
-            var lambdaFunc = _lambdaize(func);
+            var externals = _getExternalDependencies(deps);
+            var lambdaFunc = _lambdaize(func, externals);
             var functionAsString = 'exports.' + global.constants.MODULE_DEFAULT_HANDLER + '=' + lambdaFunc + ';';
 
             var zippedFunction  = zipper.zipFunction(functionAsString, deps),
@@ -182,7 +175,8 @@ module.exports = function (aws) {
                 }
             }
 
-            var moduleOverride  = _lambdaizeModule(handlerName);
+            var externals = _getExternalDependencies(deps);
+            var moduleOverride  = _lambdaizeModule(handlerName, externals);
             var zippedModule    = zipper.zipModule(moduleOverride, modulePath, deps);
             var uploadPromise   = this.uploader(zippedModule, functionConfig, functionIdentifier);
 

--- a/lib/LambdaHelper.js
+++ b/lib/LambdaHelper.js
@@ -122,8 +122,7 @@ var _getExternalDependencies = function(deps) {
     // This is going to change in the next major version, but we had to do so to keep the current API signature
     if(!deps) return [];
     return deps.filter(function(dep) {
-        // External dependencies have a prepending ":"
-        return dep[0] === ':';
+        return dep[0] === global.constants.EXTERNALS_PREPENDING_STR;
     });
 };
 

--- a/lib/internals/_callbackHandler.js
+++ b/lib/internals/_callbackHandler.js
@@ -10,13 +10,13 @@ module.exports.getCallback = function(event, context) {
 	        QueueUrl: event.sqsQueueUrl
 	    };
 	    sqs_svc.sendMessage(params, function(err) {
-	        if(err) console.log('Error sending response to sqs'); 
+	        if(err) utils.log('Error sending response to SQS'); 
 	        afterSentCallback();
 	    });
 	}
 
 	function _newCallback(arg) {
-	    var finishExecution = function() { context.done(null, "Lambdaws done"); };
+	    var finishExecution = function() { context.done(null, "Lambdaws DONE"); };
 	    var success = !(arg instanceof utils.LambdaError);
 	    _sendToSqs({success: success, data: arg, requestId: context.invokeid}, finishExecution);
 	}

--- a/lib/internals/_callbackHandler.js
+++ b/lib/internals/_callbackHandler.js
@@ -1,0 +1,25 @@
+var AWS = require('aws-sdk');
+var utils = require('./_utils');
+var sqs_svc = new AWS.SQS();
+
+module.exports.getCallback = function(event, context) {
+
+	function _sendToSqs(data, afterSentCallback) {
+	    var params = {
+	        MessageBody: JSON.stringify(data),
+	        QueueUrl: event.sqsQueueUrl
+	    };
+	    sqs_svc.sendMessage(params, function(err) {
+	        if(err) console.log('Error sending response to sqs'); 
+	        afterSentCallback();
+	    });
+	}
+
+	function _newCallback(arg) {
+	    var finishExecution = function() { context.done(null, "Lambdaws done"); };
+	    var success = !(arg instanceof utils.LambdaError);
+	    _sendToSqs({success: success, data: arg, requestId: context.invokeid}, finishExecution);
+	}
+
+	return _newCallback;
+};

--- a/lib/internals/_externalsHandler.js
+++ b/lib/internals/_externalsHandler.js
@@ -1,0 +1,54 @@
+// Add /tmp/libs to the process PATH so we can execute custom libraries
+process.env['PATH'] = process.env['PATH'] + ':/tmp/libs';
+var AWS = require('aws-sdk');
+var utils = require('./_utils');
+var s3 = new AWS.S3();
+var fs = require('fs');
+var cp = require('child_process');
+
+module.exports.installExternals = function(externals, callback) {
+	
+	if(externals.length === 0) {
+		callback(); 
+		return;
+	}
+
+	var installedCount = 0;
+
+	var downloadInstallationScript = function(lib, next) {
+		var installationFilePath = "/tmp/" + lib + "_install";
+		var libS3Path = lib.toLowerCase() + "/install_default";
+		
+		console.log('Lambdaws: Downloading Library ' + lib);
+
+		var libStream = fs.createWriteStream(installationFilePath, { mode: 0777 }); // +rwx all users
+		s3.getObject({ Bucket: 'lambdaws-libs', Key: libS3Path }).createReadStream().pipe(libStream);
+		libStream.on('finish', function(err, data) { next(installationFilePath) });
+		libStream.on('error', function(err, data) { callback(utils.objectifyError(err)) });
+	};
+
+	var installLibrary = function(installationFilePath) { 
+		console.log('Lambdaws: Installing Library ' + installationFilePath);
+		cp.exec(installationFilePath, function(err, stdout, stderr) {
+			console.log('Lambdaws: Installed Library [' + installedCount + '/' + externals.length + '] => ' + installationFilePath);
+			if(++installedCount === externals.length) {
+				console.log('Lambdaws: All libs installed');
+				callback();
+			}
+		});
+	};
+
+	// Downloading WGET from Lambdaws S3 Bucket
+	console.log('Lambdaws: getting WGET to download external libs');
+	var wgetStream = fs.createWriteStream("/tmp/wget", { mode: 0777 });
+	s3.getObject({ Bucket: 'lambdaws-libs', Key: 'wget' }).createReadStream().pipe(wgetStream);
+	wgetStream.on('finish', function(err, data) {
+		console.log('Lambdaws: WGET downloaded');
+		for(var i in externals) {
+			var libraryName = externals[i].substr(1); // trimming out the :
+			downloadInstallationScript(libraryName, function(installationFilePath) {
+				installLibrary(installationFilePath);
+			});
+		}
+	}).on('error', function(err, data) { callback(utils.objectifyError(err)) });
+};

--- a/lib/internals/_externalsHandler.js
+++ b/lib/internals/_externalsHandler.js
@@ -61,16 +61,11 @@ module.exports.installExternals = function(externals, callback) {
 	// Downloading WGET from Lambdaws S3 Bucket
 	utils.log('Downloading wget');
 	
-	try {
-		var wgetStream = fs.createWriteStream("/tmp/wget", { mode: 0777 });
+	
+	var wgetStream = fs.createWriteStream("/tmp/wget", { mode: 0777 });
 	s3.getObject({ Bucket: 'lambdaws-libs', Key: 'wget' }).createReadStream().pipe(wgetStream);
 
 	wgetStream
 		.on('finish', onWgetDownloaded)
 		.on('error', onWgetDownloadError);
-	}
-	catch(e) {
-		callback(utils.objectifyError(e));
-	}
-	
 };

--- a/lib/internals/_externalsHandler.js
+++ b/lib/internals/_externalsHandler.js
@@ -9,7 +9,7 @@ process.env['PATH'] = process.env['PATH'] + ':/tmp/libs';
 
 module.exports.installExternals = function(externals, callback) {
 	
-	if(externals.length === 0) {
+	if(!externals.length) {
 		callback(); 
 		return;
 	}
@@ -60,7 +60,6 @@ module.exports.installExternals = function(externals, callback) {
 
 	// Downloading WGET from Lambdaws S3 Bucket
 	utils.log('Downloading wget');
-	
 	
 	var wgetStream = fs.createWriteStream("/tmp/wget", { mode: 0777 });
 	s3.getObject({ Bucket: 'lambdaws-libs', Key: 'wget' }).createReadStream().pipe(wgetStream);

--- a/lib/internals/_externalsHandler.js
+++ b/lib/internals/_externalsHandler.js
@@ -1,10 +1,11 @@
+var AWS = require('aws-sdk'),
+	utils = require('./_utils'),
+	s3 = new AWS.S3({ endpoint: 's3-external-1.amazonaws.com' }),
+	fs = require('fs'),
+	cp = require('child_process');
+
 // Add /tmp/libs to the process PATH so we can execute custom libraries
 process.env['PATH'] = process.env['PATH'] + ':/tmp/libs';
-var AWS = require('aws-sdk');
-var utils = require('./_utils');
-var s3 = new AWS.S3();
-var fs = require('fs');
-var cp = require('child_process');
 
 module.exports.installExternals = function(externals, callback) {
 	
@@ -19,36 +20,57 @@ module.exports.installExternals = function(externals, callback) {
 		var installationFilePath = "/tmp/" + lib + "_install";
 		var libS3Path = lib.toLowerCase() + "/install_default";
 		
-		console.log('Lambdaws: Downloading Library ' + lib);
+		utils.log('Downloading Library', lib);
 
 		var libStream = fs.createWriteStream(installationFilePath, { mode: 0777 }); // +rwx all users
 		s3.getObject({ Bucket: 'lambdaws-libs', Key: libS3Path }).createReadStream().pipe(libStream);
+
 		libStream.on('finish', function(err, data) { next(installationFilePath) });
 		libStream.on('error', function(err, data) { callback(utils.objectifyError(err)) });
 	};
 
 	var installLibrary = function(installationFilePath) { 
-		console.log('Lambdaws: Installing Library ' + installationFilePath);
+		utils.log('Installing Library', installationFilePath);
 		cp.exec(installationFilePath, function(err, stdout, stderr) {
-			console.log('Lambdaws: Installed Library [' + installedCount + '/' + externals.length + '] => ' + installationFilePath);
+			utils.log('Installed Library', installationFilePath);
 			if(++installedCount === externals.length) {
-				console.log('Lambdaws: All libs installed');
+				utils.log('All libs installed');
 				callback();
 			}
 		});
 	};
 
-	// Downloading WGET from Lambdaws S3 Bucket
-	console.log('Lambdaws: getting WGET to download external libs');
-	var wgetStream = fs.createWriteStream("/tmp/wget", { mode: 0777 });
-	s3.getObject({ Bucket: 'lambdaws-libs', Key: 'wget' }).createReadStream().pipe(wgetStream);
-	wgetStream.on('finish', function(err, data) {
-		console.log('Lambdaws: WGET downloaded');
+	var installAllLibraries = function() {
 		for(var i in externals) {
-			var libraryName = externals[i].substr(1); // trimming out the :
+			var libraryName = externals[i].substr(1); // trimming out the prepending ":"
 			downloadInstallationScript(libraryName, function(installationFilePath) {
 				installLibrary(installationFilePath);
 			});
 		}
-	}).on('error', function(err, data) { callback(utils.objectifyError(err)) });
+	};
+
+	var onWgetDownloaded = function() {
+		utils.log('wget downloaded');
+		installAllLibraries();
+	};
+
+	var onWgetDownloadError = function(err) {
+		callback(utils.objectifyError(err));
+	};
+
+	// Downloading WGET from Lambdaws S3 Bucket
+	utils.log('Downloading wget');
+	
+	try {
+		var wgetStream = fs.createWriteStream("/tmp/wget", { mode: 0777 });
+	s3.getObject({ Bucket: 'lambdaws-libs', Key: 'wget' }).createReadStream().pipe(wgetStream);
+
+	wgetStream
+		.on('finish', onWgetDownloaded)
+		.on('error', onWgetDownloadError);
+	}
+	catch(e) {
+		callback(utils.objectifyError(e));
+	}
+	
 };

--- a/lib/internals/_utils.js
+++ b/lib/internals/_utils.js
@@ -9,3 +9,8 @@ var objectifyError = function(err) {
 
 module.exports.LambdaError = LambdaError;
 module.exports.objectifyError = objectifyError;
+module.exports.log = function() {
+	var args = Array.prototype.slice.call(arguments);
+	args.splice(0,0, "<<LAMBDAWS>>");
+	console.log.apply(this, args);
+};

--- a/lib/internals/_utils.js
+++ b/lib/internals/_utils.js
@@ -1,0 +1,11 @@
+var LambdaError = function() {};
+
+var objectifyError = function(err) {
+    return Object.getOwnPropertyNames(err).reduce(function(a, c) {
+        a[c] = err[c];
+        return a;
+    }, new LambdaError());
+};
+
+module.exports.LambdaError = LambdaError;
+module.exports.objectifyError = objectifyError;

--- a/lib/lambdaws.js
+++ b/lib/lambdaws.js
@@ -31,8 +31,9 @@ var relativeDir = path.dirname(module.parent.parent.filename);
 
 function _resolvePathFromParent(p) {
     try {
-        // For built in or global modules
+        // Deps with prepending ":" are external dependencies. We do not resolve them; we process them differently
         if(p[0] === ':') return p;
+        // For built in or global modules
         return require.resolve(p);
     }
     catch(ex1) { // Not found

--- a/lib/lambdaws.js
+++ b/lib/lambdaws.js
@@ -8,7 +8,7 @@ global.settings = {
     credentials: null,
     region: 'us-west-2',
     sqsQueueName: 'LambdaResultsQueue',
-    uploadTimeout: 5000
+    uploadTimeout: 10000
 };
 
 global.constants = {

--- a/lib/lambdaws.js
+++ b/lib/lambdaws.js
@@ -32,6 +32,7 @@ var relativeDir = path.dirname(module.parent.parent.filename);
 function _resolvePathFromParent(p) {
     try {
         // For built in or global modules
+        if(p[0] === ':') return p;
         return require.resolve(p);
     }
     catch(ex1) { // Not found

--- a/lib/lambdaws.js
+++ b/lib/lambdaws.js
@@ -15,7 +15,8 @@ global.constants = {
     MODULE_HASH_PREFIX: 'fromModule',
     MODULE_DEFAULT_HANDLER: 'default',
     LAMBDA_RUNTIME: 'nodejs',
-    LAMBDA_MODE: 'event'
+    LAMBDA_MODE: 'event',
+    EXTERNALS_PREPENDING_STR: ':'
 };
 
 var _lambdaHelper = null;
@@ -31,8 +32,7 @@ var relativeDir = path.dirname(module.parent.parent.filename);
 
 function _resolvePathFromParent(p) {
     try {
-        // Deps with prepending ":" are external dependencies. We do not resolve them; we process them differently
-        if(p[0] === ':') return p;
+        if(p[0] === global.constants.EXTERNALS_PREPENDING_STR) return p;
         // For built in or global modules
         return require.resolve(p);
     }

--- a/lib/zipper.js
+++ b/lib/zipper.js
@@ -28,7 +28,11 @@ var _getDependencyFolder = function(dep) {
 };
 
 var _addDepsToZip = function(_zip, deps){
-    var depsFolders = deps.map(function(dep) {
+    var depsFolders = deps
+    .filter(function(dep){
+        return dep[0] !== ':';
+    })
+    .map(function(dep) {
         return _getDependencyFolder(dep);
     }).filter(function(dep){
         // we exclude those deps because they are built-in node and zipping . folder is not wanted
@@ -55,10 +59,21 @@ var _addFolderRecursiveToZipNode = function(folder, zipNode) {
     });
 };
 
+var _addHandlersToZip = function(zip) {
+        var callbackHandlerFile = fs.readFileSync(__dirname + '/internals/_callbackHandler.js');
+        var externalsHandlerFile = fs.readFileSync(__dirname + '/internals/_externalsHandler.js');
+        var utilsFile = fs.readFileSync(__dirname + '/internals/_utils.js');
+
+        zip.file('_callbackHandler.js', callbackHandlerFile);
+        zip.file('_externalsHandler.js', externalsHandlerFile);
+        zip.file('_utils.js', utilsFile);
+};
+
 module.exports = {
     zipFunction : function(stringFunc, deps){
         var _zip = zip();
         _zip.file('index.js', stringFunc);
+        _addHandlersToZip(_zip);
 
         if (deps) {
             _addDepsToZip(_zip, deps);            
@@ -68,10 +83,12 @@ module.exports = {
     },
     zipModule : function(moduleOverride, modulePath, deps){
         var _zip = zip();
+
         var moduleFile = fs.readFileSync(modulePath);
         
         _zip.file('module.js', moduleFile);
         _zip.file('index.js', moduleOverride);
+        _addHandlersToZip(_zip);
 
         if (deps) {
             _addDepsToZip(_zip, deps);            


### PR DESCRIPTION
Provides a mechanism for installing external libraries on a Lambda node like PhantomJS.
The process is the following:
- External dependencies are defined at the same place as the normal dependencies but have a prepending ":". Example: ```['Q', 'async', ':phantomjs']```. PhantomJS is external
- External libraries are defined in repo "mentum/lambdaws-libs". They are uploaded to S3 in the us-east-1 lambdaws-libs bucket
- Upon function execution, we do the following:
- Add the /tmp/libs to the PATH env. variable so the libs are accessible from node process directly
- We download wget
- We download the installation scripts
- We run the installation scripts. They use wget to download the lib, much faster than s3.getObject.