### PR TITLE
Adding project-specific deps is working

### DIFF
--- a/lib/LambdaHelper.js
+++ b/lib/LambdaHelper.js
@@ -227,7 +227,7 @@ module.exports = function (aws) {
                 }
             }
 
-            var externals = _getExternalDependencies(deps);
+            var externals       = _getExternalDependencies(deps);
             var moduleOverride  = _lambdaizeModule(handlerName, externals);
             var zippedModule    = zipper.zipModule(moduleOverride, modulePath, deps, configs);
             var uploadPromise   = this.uploader(zippedModule, functionConfig, functionIdentifier);

--- a/lib/extensions/string.js
+++ b/lib/extensions/string.js
@@ -1,0 +1,5 @@
+if (typeof String.prototype.startsWith != 'function') {
+  String.prototype.startsWith = function (str){
+    return this.slice(0, str.length) == str;
+  };
+}

--- a/lib/lambdaws.js
+++ b/lib/lambdaws.js
@@ -4,6 +4,8 @@ var extend = require('extend'),
     LambdaHelper = require('./LambdaHelper'),
     path = require('path');
 
+require('./extensions/string');
+
 global.settings = {
     credentials: null,
     region: 'us-west-2',
@@ -16,7 +18,9 @@ global.constants = {
     MODULE_DEFAULT_HANDLER: 'default',
     LAMBDA_RUNTIME: 'nodejs',
     LAMBDA_MODE: 'event',
-    EXTERNALS_PREPENDING_STR: ':'
+    EXTERNALS_PREPENDING_STR: ':',
+    INTERNALS_PREPENDING_STR: '+',
+    INTERNALS_FOLDER_NAME: 'project_files'
 };
 
 var _lambdaHelper = null;
@@ -31,18 +35,26 @@ var versions = {
 var relativeDir = path.dirname(module.parent.parent.filename);
 
 function _resolvePathFromParent(p) {
+    
+    var prependingStr = '';
+    if(p.startsWith(global.constants.INTERNALS_PREPENDING_STR)) {
+        prependingStr = global.constants.INTERNALS_PREPENDING_STR;
+        p = p.substr(global.constants.INTERNALS_PREPENDING_STR.length);
+    }
+
     try {
-        if(p[0] === global.constants.EXTERNALS_PREPENDING_STR) return p;
+        if(p.startsWith(global.constants.EXTERNALS_PREPENDING_STR)) return p;
+
         // For built in or global modules
-        return require.resolve(p);
+        return prependingStr + require.resolve(p);
     }
     catch(ex1) { // Not found
         var fullPath = path.join(relativeDir, p);
         try {
-            return require.resolve(fullPath);
+            return prependingStr + require.resolve(fullPath);
         }
         catch(ex2) { // Not found
-            throw Error("Could not resolve module [" + p + "] from [" + relativeDir + "] at [" + fullPath + "]");
+            throw new Error("Could not resolve module [" + p + "] from [" + relativeDir + "] at [" + fullPath + "]");
         }
     }
 }

--- a/lib/zipper.js
+++ b/lib/zipper.js
@@ -85,7 +85,7 @@ var _addInternalsToZip = function(zip, deps) {
     for(var i in internals) {
         var internal = internals[i].substr(global.constants.INTERNALS_PREPENDING_STR.length);
         var fileName = path.basename(internal);
-        node.file('fileName.js', fs.readFileSync(internal));
+        node.file(fileName, fs.readFileSync(internal));
     }
 };
 

--- a/lib/zipper.js
+++ b/lib/zipper.js
@@ -2,6 +2,8 @@ var fs      = require('fs'),
     zip     = require('node-zip'),
     path    = require('path');
 
+require('./extensions/string');
+
 var DEPENDENCIES_DEFAULT_FOLDER = 'node_modules',
     MAX_LAMBDA_ZIP_SIZE         = 25e+6;
     
@@ -15,7 +17,7 @@ var _generateZip = function(_zip){
     if(zipped.length >= MAX_LAMBDA_ZIP_SIZE) {
         throw Error('The zipped function is larger than the maximum file zipe you can upload to AWS Lambda');
     }
-    
+
     return zipped; 
 }
 
@@ -30,7 +32,8 @@ var _getDependencyFolder = function(dep) {
 var _addDepsToZip = function(_zip, deps){
     var depsFolders = deps
     .filter(function(dep){
-        return dep[0] !== ':';
+        return !dep.startsWith(global.constants.EXTERNALS_PREPENDING_STR)
+            && !dep.startsWith(global.constants.INTERNALS_PREPENDING_STR);
     })
     .map(function(dep) {
         return _getDependencyFolder(dep);
@@ -70,11 +73,28 @@ var _addHandlersToZip = function(zip, configs) {
         zip.file('_utils.js', utilsFile);
 };
 
+var _addInternalsToZip = function(zip, deps) {
+    var internals = deps.filter(function(d) {
+        return d.startsWith(global.constants.INTERNALS_PREPENDING_STR);
+    });
+
+    if(internals.length === 0) return;
+
+    var node = zip.folder(global.constants.INTERNALS_FOLDER_NAME);
+    
+    for(var i in internals) {
+        var internal = internals[i].substr(global.constants.INTERNALS_PREPENDING_STR.length);
+        var fileName = path.basename(internal);
+        node.file('fileName.js', fs.readFileSync(internal));
+    }
+};
+
 module.exports = {
     zipFunction : function(stringFunc, deps, configs){
         var _zip = zip();
         _zip.file('index.js', stringFunc);
         _addHandlersToZip(_zip, configs);
+        _addInternalsToZip(_zip, deps);
 
         if (deps) {
             _addDepsToZip(_zip, deps);            
@@ -90,6 +110,7 @@ module.exports = {
         _zip.file('module.js', moduleFile);
         _zip.file('index.js', moduleOverride);
         _addHandlersToZip(_zip, configs);
+        _addInternalsToZip(_zip, deps);
 
         if (deps) {
             _addDepsToZip(_zip, deps);            


### PR DESCRIPTION
You can now include project-specific files in the zip by prepending the dependency with `+`. For example `+./template.html`. All the project-specific files will be places in the zip under the `project_files` folder.