### PR TITLE
Fixed the version in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambdaws",
-  "version": "1.0.10",
+  "version": "1.0.12",
   "description": "AWS lambda functions made easy",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
`1.0.12` is the latest according to what's on npm

I believe this may fix the issue about not being able to install using `npm install`
It might be pulling `1.0.10` that actually does not have the `bin/` folder.