### PR TITLE
Added support for S3 events

### DIFF
--- a/lib/LambdaHelper.js
+++ b/lib/LambdaHelper.js
@@ -36,28 +36,39 @@ var _loadModule = function(moduleName) {
 };
 
 var _lambdaize = function (userFunc, externals) {
-    
+
     // This function is a template that is serialized and some parts are replaced
     function __lambda__ (event, context) {
         var utils               = require('./_utils'),
             callbackHandler     = require('./_callbackHandler'),
-            externalsHandler    = require('./_externalsHandler');
+            externalsHandler    = require('./_externalsHandler'),
+            invokedByLambdaws   = typeof event.args !== 'undefined';
 
         var doneCallback = callbackHandler.getCallback(event, context);
 
-        event.args.push(doneCallback);
+        if (invokedByLambdaws) {
+            // If invoked by Lambdaws, we can add a callback as last arg
+            event.args.push(doneCallback);
+        }
+
         var externals = /*externals*/null; // The external libraries to install, injected below
         var func = /*user function*/null; // The user function or module to run, injected below
 
         var runUserFunction = function() {
             try {
-            func.apply(this, event.args);
-            }
-            catch(error) {
+                if (invokedByLambdaws) {
+                    func.apply(this, event.args);
+                } else {
+                    // Invoked by an AWS event (S3 PUT for instance)
+                    // We need to pass the event object because it contains
+                    // valuable info from the caller (bucket name, key, etc.)
+                    func.apply(this, [event, context]);
+                }
+            } catch(error) {
                 doneCallback(utils.objectifyError(error));
             }
         };
-        
+
         try { externalsHandler.installExternals(externals, runUserFunction) }
         catch(error) { doneCallback(utils.objectifyError(error)) }
     }
@@ -87,7 +98,7 @@ var _createFeedbackRoot = function(feedbackStore, functionName, requestId, callb
         timerKey    = functionName + '.timer';
 
     if(!feedbackStore.hasOwnProperty(functionName)) {
-        
+
         var src = new hose.Source({
             aws: _awsConfig,
             LogGroup: '/aws/lambda/' + functionName,
@@ -98,7 +109,7 @@ var _createFeedbackRoot = function(feedbackStore, functionName, requestId, callb
                 var log = batch[i];
                 // Timeouts handling
                 if(log.message.match(/Task timed out after/gi)) {
-                    feedbackStore[requestKey].call(null, new Error(log.message.trim()));    
+                    feedbackStore[requestKey].call(null, new Error(log.message.trim()));
                 }
             }
         });
@@ -166,7 +177,7 @@ var _createProxy = function (executionStore, feedbackStore, functionIdentifier, 
 };
 
 var _getExternalDependencies = function(deps) {
-    // External dependencies are currently defined within the normal dependencies. 
+    // External dependencies are currently defined within the normal dependencies.
     // This is going to change in the next major version, but we had to do so to keep the current API signature
     if(!deps) return [];
     return deps.filter(function(dep) {
@@ -199,7 +210,7 @@ module.exports = function (aws) {
 
             var zippedFunction  = zipper.zipFunction(functionAsString, deps, configs),
                 uploadPromise   = this.uploader(zippedFunction, functionConfig, functionIdentifier);
-            
+
             proxyStore[functionIdentifier] = this.createProxy(executionStore, feedbackStore, functionIdentifier, _sqsHelper.initializedPromise, uploadPromise);
         }
 
@@ -209,7 +220,7 @@ module.exports = function (aws) {
     this.getCloudedFunctionFromModule = function(modulePath, handlerName, deps, configs) {
         var functionConfig = extend(true, {}, _defaultFunctionSettings, configs);
         var functionIdentifier = _getModuleHash(modulePath, handlerName, deps, functionConfig);
-        
+
         if(!proxyStore.hasOwnProperty(functionIdentifier)) {
             var _module = _loadModule(modulePath);
 


### PR DESCRIPTION
Like explained in the Gitter room, the current implementation only supports lambda called from a local process through the proxy (like in the examples). So, it builds an args array and passes it to the user function. However, with invocation from S3, we need the whole `event` object passed in. This fix adds that flexibility.

This is not the best fix but it is working fine. I'm sure there are ways to find a more elegant solution down the road. It would be great to figure out what triggered the lambda and adjust the user function call accordingly for instance.