### PR TITLE
As per the README example, works without specifying the lambda function's config

### DIFF
--- a/lib/lambdaws.js
+++ b/lib/lambdaws.js
@@ -77,7 +77,9 @@ function _createFromInlinedFunction() {
         return _resolvePathFromParent(d);
     });
 
-    return _lambdaHelper.getCloudedFunctionFromFunction(arguments[0], resolvedDeps, arguments[2]);
+    var config = arguments[2] || {};
+
+    return _lambdaHelper.getCloudedFunctionFromFunction(arguments[0], resolvedDeps, config);
 };
 
 function _createFromModule() {
@@ -90,11 +92,11 @@ function _createFromModule() {
     if(typeof(arguments[1]) === 'string') {
         handlerName = arguments[1];
         deps = arguments[2] || [];
-        configs = arguments[3];
+        configs = arguments[3] || {};
     } else {
         handlerName = null;
         deps = arguments[1] || [];
-        configs = arguments[2];
+        configs = arguments[2] || {};
     }
 
     _injectAwsSdkIntoDeps(deps);


### PR DESCRIPTION
The README.md specifies the following example but it didn't work because it needs a object for config.

> var cloudedCalculator = λ(calculator);

This pull request adds an empty object as default.