### PR TITLE
Added 'logs:*' as a required permission in README and added a more verbose error message for ResourceNotFoundException in CloudWatch hose

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Please note that `λ` is used here only for shortening the code and for clarity.
 var λ = require('lambdaws').create;
 
 // A simple inlined asynchronous function computing A + B
-var calculator = function(a, b, callback) { 
+var calculator = function(a, b, callback) {
 	callback(a + b);
 };
 
@@ -128,7 +128,7 @@ You can set your AWS credentials in one of three ways.
    lambdaws.start();
    ```
 
-The lambda function will run in the `role` specified. It must be an ARN of the IAM role that has `s3:GetObject`, `sqs:SendMessage`, and `lambda:InvokeFunction` allowed. The `AWSLambdaExecute` managed policy can be used in place of `lambda:InvokeFunction`.  Your lambda functions may require additional permissions on the `role` if they use other AWS services.
+The lambda function will run in the `role` specified. It must be an ARN of the IAM role that has `s3:GetObject`, `sqs:SendMessage`, `lambda:InvokeFunction`, and `logs:*` allowed. The `AWSLambdaExecute` managed policy can be used in place of `lambda:InvokeFunction`.  Your lambda functions may require additional permissions on the `role` if they use other AWS services.
 
 The `credentials` must be for a user that can has allowed policies for `sqs:CreateQueue`, `sqs:DeleteMessage` and `lambda:*` actions.
 

--- a/lib/LambdaHelper.js
+++ b/lib/LambdaHelper.js
@@ -116,7 +116,12 @@ var _createFeedbackRoot = function(feedbackStore, functionName, requestId, callb
 
         src.on('error', function(error) {
             // TODO Handle errors gracefully
-            console.log('Clouwatch hose error -->', error);
+            if (error.name === 'ResourceNotFoundException') {
+              error.message = 'LogGroup \'/aws/lambda/' + functionName + '\' was not found. ' +
+                              'Amazon Lambda will create the proper LogGroup upon execution, but it will fail unless the role ' +
+                              'has been allowed Access on \'logs:*\'.';
+            }
+            console.log('Cloudwatch hose error -->', error);
         });
 
         feedbackStore[functionName] = [];


### PR DESCRIPTION
Added `logs:*` as a required permission for IAM role in the README. Added a more verbose error message for ResourceNotFoundException. Amazon Lambda will not create the LogGroup for our lambda if our role isn't granted `logs:*`
